### PR TITLE
Title tag snippet

### DIFF
--- a/title.html
+++ b/title.html
@@ -1,0 +1,7 @@
+  <title>
+    {% if page.title %}
+      {{ page.title }}
+    {% else %}
+      {{ site.title }}
+    {% endif %}
+  </title>


### PR DESCRIPTION
A snippet that makes the `title` tag take either the title of the page, or if there is no title present, the default title from `_config.rb`
