### PR TITLE
Add reading time snippet

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ I'm a big fan of Jekyll. I've built [my blog](http://markdotto.com) on it, as we
 - [List of posts in a category](posts-in-category.html).
 - [Paginated posts](posts-pagination.html) with `<span>`s, `<a>`s, classes, and more.
 - [Link to next post](posts-next-post.html).
+- [Reading time](reading-time.html)
 
 ### Pages
 

--- a/reading-time.html
+++ b/reading-time.html
@@ -1,0 +1,6 @@
+{% capture words %}
+  {{ page.content | number_of_words | minus: 180 }}
+{% endcapture %}
+{% unless words contains "-" %}
+  <span class="reading-time">{{ words | plus: 180 | divided_by: 180 | pluralize: "minute to read", "minutes to read" }}</span>
+{% endunless %}


### PR DESCRIPTION
This snippet can be used to display an estimated "x minutes to read" on post pages. It's only displayed on posts that take at least one minute to read, because it wouldn't make too much sense otherwise. I've written about this snippet [here](http://sacha.me/articles/jekyll-word-counts/).
